### PR TITLE
Feat/post topic creation

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -32,9 +32,9 @@ custom:
   kmsSecrets: ${file(kms-secrets.${opt:stage, self:provider.stage}.${opt:region, self:provider.region}.yml)}
 
 functions:
-  topic_create:
-    handler: src/api_handler.topic_create
-    description: Creates a new topic
+  topic_post:
+    handler: src/api_handler.topic_post
+    description: Creates a new topic, or updates an existing one
     events:
       - http:
          path: topic/{id}

--- a/src/api/__tests__/topic_get.test.js
+++ b/src/api/__tests__/topic_get.test.js
@@ -41,7 +41,7 @@ describe("TopicGetHandler", () => {
         {},
         (err, res) => {
           expect(err).toBeNull();
-          expect(res).toEqual({
+          expect(res.body).toEqual({
             topic: {
               id: newTopicId,
               content: ""
@@ -55,7 +55,7 @@ describe("TopicGetHandler", () => {
       topicMgr.read.mockReturnValue(record);
       await sut.handle({ pathParameters: { id: topicId } }, {}, (err, res) => {
         expect(err).toBeNull();
-        expect(res).toEqual({ topic: record });
+        expect(res.body).toEqual({ topic: record });
       });
     });
   });

--- a/src/api/__tests__/topic_post.test.js
+++ b/src/api/__tests__/topic_post.test.js
@@ -36,18 +36,18 @@ describe("TopicPostHandler", () => {
 
         test("no topic id", async () => {
             await sut.handle({ pathParameters: {other: "thing"}, body: JSON.stringify(record)}, null, (err, res) => {
-                expect(err).not.toBeNull();
-                expect(err.code).toEqual(400);
-                expect(err.message).toEqual("No topic id");
-            });
+                expect(err).toBeNull()
+                expect(res.code).toEqual(201)
+                expect(res.body.message).toEqual('created')
+                expect(res.headers.Location).toMatch(/^\/topic\/[a-zA-Z0-9_-]{16}/)
+              });
         });
 
         test("happy path", async () => {
             await sut.handle({ pathParameters: {id: newTopicId}, body: JSON.stringify(record)}, null, (err, res) => {
                 expect(err).toBeNull();
-                expect(res.message).toEqual("created");
+                expect(res.body.message).toEqual('updated');
             });
         });
-
     });
 });

--- a/src/api/__tests__/topic_post.test.js
+++ b/src/api/__tests__/topic_post.test.js
@@ -45,7 +45,7 @@ describe("TopicPostHandler", () => {
         test("happy path", async () => {
             await sut.handle({ pathParameters: {id: newTopicId}, body: JSON.stringify(record)}, null, (err, res) => {
                 expect(err).toBeNull();
-                expect(res.message).toEqual("updated");
+                expect(res.message).toEqual("created");
             });
         });
 

--- a/src/api/topic_get.js
+++ b/src/api/topic_get.js
@@ -20,7 +20,7 @@ class TopicGetHandler {
                 cb({ code: 500, message: error.message })
                 return;
             }
-            cb(null, { topic: topic })
+            cb(null, { data: { topic: topic } })
             return;
         } else {
             cb({ code: 400, message: "No topic id" });

--- a/src/api/topic_get.js
+++ b/src/api/topic_get.js
@@ -20,7 +20,7 @@ class TopicGetHandler {
                 cb({ code: 500, message: error.message })
                 return;
             }
-            cb(null, { data: { topic: topic } })
+            cb(null, { body: { topic: topic } })
             return;
         } else {
             cb({ code: 400, message: "No topic id" });

--- a/src/api/topic_post.js
+++ b/src/api/topic_post.js
@@ -28,7 +28,7 @@ class TopicPostHandler {
                 cb({ code: 500, message: error.message })
                 return
             }
-            cb(null, { code: 200, data: { message: "updated" } });
+            cb(null, { code: 200, body: { message: "updated" } });
             return;
         } else {
           // Create a new (unused) topic
@@ -39,7 +39,9 @@ class TopicPostHandler {
           } while (topic)
           topic = await this.topicMgr.create(topicId)
           console.log("topic created: " + topicId)
-          cb(null, { code: 201, data: { message: "created" }, headers: {Location: `/topic/${topicId}`})
+          // Set topic after creating new one
+          await this.topicMgr.update(topicId, body)
+          cb(null, { code: 201, body: { message: "created" }, headers: {Location: `/topic/${topicId}`} })
           return
         }
 

--- a/src/api/topic_post.js
+++ b/src/api/topic_post.js
@@ -4,38 +4,51 @@ class TopicPostHandler {
         this.topicMgr = topicMgr
     }
 
+    /**
+     * Handle a post request for a given topic ID, by creating one if none
+     * exists, or updating an existing topic.  Respond by calling cb with 
+     * message 'created' or 'updated' as appropriate
+     * @param {Object} event 
+     * @param {Object} context 
+     * @param {Function} cb 
+     */
     async handle(event, context, cb) {
-
-        //Parse body
-        let body;
+        // Parse body
+        let body
         try {
             body = JSON.parse(event.body)
         } catch (e) {
             cb({ code: 403, message: 'no json body'})
-            return;
+            return
         }
 
         if (event.pathParameters && event.pathParameters.id) {
-            let topicId;
+            let topicId, message = 'updated'
             topicId = event.pathParameters.id
             try {
+                // First check for existing topic
+                topic = await this.topicMgr.read(topicId)
+                if (!topic) {
+                  // Create topic if none exists, and set response message to 'created'
+                  message = 'created'
+                  topic = await this.topicMgr.create(topicId)
+                  console.log("topic created: " + topicId)
+                }
                 await this.topicMgr.update(topicId, body)
                 console.log("topic updated: " + topicId)
             } catch (error) {
                 console.log("Error on this.topicMgr.update")
                 console.log(error)
                 cb({ code: 500, message: error.message })
-                return;
+                return
             }
-            cb(null, { message: "updated" });
-            return;
+            cb(null, { message })
+            return
         } else {
-            cb({ code: 400, message: "No topic id" });
-            return;
+            cb({ code: 400, message: "No topic id" })
+            return
         }
-
     }
-
 }
 
 module.exports = TopicPostHandler

--- a/src/api/topic_post.js
+++ b/src/api/topic_post.js
@@ -4,36 +4,21 @@ class TopicPostHandler {
         this.topicMgr = topicMgr
     }
 
-    /**
-     * Handle a post request for a given topic ID, by creating one if none
-     * exists, or updating an existing topic.  Respond by calling cb with 
-     * message 'created' or 'updated' as appropriate
-     * @param {Object} event 
-     * @param {Object} context 
-     * @param {Function} cb 
-     */
     async handle(event, context, cb) {
-        // Parse body
-        let body
+
+        //Parse body
+        let body;
         try {
             body = JSON.parse(event.body)
         } catch (e) {
             cb({ code: 403, message: 'no json body'})
-            return
+            return;
         }
 
         if (event.pathParameters && event.pathParameters.id) {
-            let topicId, message = 'updated'
+            let topicId
             topicId = event.pathParameters.id
             try {
-                // First check for existing topic
-                let topic = await this.topicMgr.read(topicId)
-                if (!topic) {
-                  // Create topic if none exists, and set response message to 'created'
-                  message = 'created'
-                  topic = await this.topicMgr.create(topicId)
-                  console.log("topic created: " + topicId)
-                }
                 await this.topicMgr.update(topicId, body)
                 console.log("topic updated: " + topicId)
             } catch (error) {
@@ -42,13 +27,27 @@ class TopicPostHandler {
                 cb({ code: 500, message: error.message })
                 return
             }
-            cb(null, { message })
-            return
+            cb(null, { message: "updated" });
+            return;
         } else {
-            cb({ code: 400, message: "No topic id" })
-            return
+          // Create a new topic
+          let topicId = randomString(16)
+          let topic = await this.topicMgr.read(topicId)
+          while (topic) {
+            topicId = randomString(16)
+            topic = await this.topicMgr.read(topicId)
+          }
+
+          // Create topic if none exists, and set response message to 'created'
+          message = 'created'
+          topic = await this.topicMgr.create(topicId)
+          console.log("topic created: " + topicId)
+          cb(null, { message: "created" })
+          return
         }
+
     }
+
 }
 
 module.exports = TopicPostHandler

--- a/src/api/topic_post.js
+++ b/src/api/topic_post.js
@@ -27,7 +27,7 @@ class TopicPostHandler {
             topicId = event.pathParameters.id
             try {
                 // First check for existing topic
-                topic = await this.topicMgr.read(topicId)
+                let topic = await this.topicMgr.read(topicId)
                 if (!topic) {
                   // Create topic if none exists, and set response message to 'created'
                   message = 'created'

--- a/src/api/topic_post.js
+++ b/src/api/topic_post.js
@@ -1,3 +1,4 @@
+const { randomString } = require('../lib/util.js')
 
 class TopicPostHandler {
     constructor(topicMgr) {
@@ -27,22 +28,18 @@ class TopicPostHandler {
                 cb({ code: 500, message: error.message })
                 return
             }
-            cb(null, { message: "updated" });
+            cb(null, { code: 200, data: { message: "updated" } });
             return;
         } else {
-          // Create a new topic
-          let topicId = randomString(16)
-          let topic = await this.topicMgr.read(topicId)
-          while (topic) {
-            topicId = randomString(16)
+          // Create a new (unused) topic
+          let topicId, topic
+          do {
+            topicId = randomString()
             topic = await this.topicMgr.read(topicId)
-          }
-
-          // Create topic if none exists, and set response message to 'created'
-          message = 'created'
+          } while (topic)
           topic = await this.topicMgr.create(topicId)
           console.log("topic created: " + topicId)
-          cb(null, { message: "created" })
+          cb(null, { code: 201, data: { message: "created" }, headers: {Location: `/topic/${topicId}`})
           return
         }
 

--- a/src/api_handler.js
+++ b/src/api_handler.js
@@ -36,13 +36,15 @@ const preHandler = (handler, event, context, callback) => {
 
 const doHandler = (handler, event, context, callback) => {
     handler.handle(event, context, (err, resp) => {
-        let response;
+        let response
         if (err == null) {
+            let { code, headers, body } = resp
             response = {
-                statusCode: 200,
+                statusCode: code || 200,
+                headers,
                 body: JSON.stringify({
                     status: 'success',
-                    data: resp
+                    ...body
                 })
             }
         } else {

--- a/src/api_handler.js
+++ b/src/api_handler.js
@@ -42,10 +42,9 @@ const doHandler = (handler, event, context, callback) => {
             response = {
                 statusCode: code || 200,
                 headers,
-                body: JSON.stringify({
-                    status: 'success',
-                    ...body
-                })
+                body: JSON.stringify(Object.assign({
+                    status: 'success'
+                }, body))
             }
         } else {
             //console.log(err);

--- a/src/lib/__tests__/topicMgr.test.js
+++ b/src/lib/__tests__/topicMgr.test.js
@@ -7,7 +7,10 @@ let pgClientMock = {
 Client.mockImplementation(() => {
   return pgClientMock;
 });
+
 const TopicMgr = require("../topicMgr");
+import { CREATE_QUERY, READ_QUERY, UPDATE_QUERY, DELETE_QUERY } from '../queries.js'
+
 
 describe("TopicMgr", () => {
     let sut;
@@ -63,10 +66,7 @@ describe("TopicMgr", () => {
         .then(resp => {
             expect(pgClientMock.connect).toBeCalled()
             expect(pgClientMock.query).toBeCalled()
-            expect(pgClientMock.query).toBeCalledWith(
-                "INSERT INTO topics(id, expiration) \
-             VALUES ($1, now() + interval '$2' second);"
-             , [topicId, expiration]);
+            expect(pgClientMock.query).toBeCalledWith(CREATE_QUERY, [topicId, expiration])
             expect(pgClientMock.end).toBeCalled()
             expect(resp.topic).toEqual("fakeTopic")
           done();
@@ -107,10 +107,7 @@ describe("TopicMgr", () => {
         .then(resp => {
             expect(pgClientMock.connect).toBeCalled();
             expect(pgClientMock.query).toBeCalled();
-            expect(pgClientMock.query).toBeCalledWith(
-                "SELECT * FROM topics \
-                    WHERE id=$1 \
-                    AND expiration > now()", [topicId]);
+            expect(pgClientMock.query).toBeCalledWith(READ_QUERY, [topicId]);
             expect(pgClientMock.end).toBeCalled();
             expect(resp).toEqual(fakeResponse);
             done();
@@ -161,11 +158,7 @@ describe("TopicMgr", () => {
         .then(resp => {
           expect(pgClientMock.connect).toBeCalled();
           expect(pgClientMock.query).toBeCalled();
-          expect(pgClientMock.query).toBeCalledWith(
-                "UPDATE topics SET \
-                content = $2 WHERE \
-                id = $1;"
-                , [topicId, content]);
+          expect(pgClientMock.query).toBeCalledWith(UPDATE_QUERY, [topicId, content]);
           expect(pgClientMock.end).toBeCalled();
           done();
         })
@@ -203,10 +196,7 @@ describe("TopicMgr", () => {
             .then(resp => {
               expect(pgClientMock.connect).toBeCalled();
               expect(pgClientMock.query).toBeCalled();
-              expect(pgClientMock.query).toBeCalledWith(
-                "DELETE FROM topics \
-                WHERE id = $1;"
-                , [topicId]);
+              expect(pgClientMock.query).toBeCalledWith(DELETE_QUERY, [topicId]);
               expect(pgClientMock.end).toBeCalled();
               done();
             })
@@ -215,7 +205,4 @@ describe("TopicMgr", () => {
               done();
             });
         });
-
-
-
 });

--- a/src/lib/queries.js
+++ b/src/lib/queries.js
@@ -1,0 +1,18 @@
+export const CREATE_QUERY = `
+  INSERT INTO topics(id, expiration) 
+  VALUES ($1, now() + interval '$2' second);
+`
+export const READ_QUERY = `
+  SELECT * FROM topics
+  WHERE id=$1
+  AND expiration > now();
+`
+export const UPDATE_QUERY = `
+  UPDATE topics 
+  SET content = $2 
+  WHERE id = $1;
+`
+export const DELETE_QUERY = `
+  DELETE FROM topics
+  WHERE id = $1;
+`

--- a/src/lib/topicMgr.js
+++ b/src/lib/topicMgr.js
@@ -1,6 +1,31 @@
 import { Client } from 'pg'
 
+const CREATE_QUERY = `
+  INSERT INTO topics(id, expiration) 
+  VALUES ($1, now() + interval '$2' second);
+`
+const READ_QUERY = `
+  SELECT * FROM topics
+  WHERE id=$1
+  AND expiration > now();
+`
+const UPDATE_QUERY = `
+  UPDATE topics 
+  SET content = $2 
+  WHERE id = $1;
+`
+const DELETE_QUERY = `
+  DELETE FROM topics
+  WHERE id = $1;
+`
 
+/**
+ * @classdesc
+ * Main class for managing topics on the Chasqui service.  A topic is simply
+ * an id with a message associated with it that supports CRUD operations,
+ * each of which is implemented as an asynchronous method of this class.
+ * 
+ */
 class TopicMgr {
 
     constructor() {
@@ -26,10 +51,7 @@ class TopicMgr {
 
         try {
             await client.connect()
-            const res = await client.query(
-                "INSERT INTO topics(id, expiration) \
-             VALUES ($1, now() + interval '$2' second);"
-                , [topicId, this.expiration]);
+            const res = await client.query(CREATE_QUERY, [topicId, this.expiration]);
             return res.rows[0];
         } catch (e) {
             throw (e);
@@ -48,10 +70,7 @@ class TopicMgr {
 
         try {
             await client.connect()
-            const res = await client.query(
-                "SELECT * FROM topics \
-                    WHERE id=$1 \
-                    AND expiration > now()", [topicId]);
+            const res = await client.query(READ_QUERY, [topicId]);
             return res.rows[0];
         } catch (e) {
             throw (e);
@@ -71,11 +90,7 @@ class TopicMgr {
 
         try {
             await client.connect()
-            const res = await client.query(
-                "UPDATE topics SET \
-                content = $2 WHERE \
-                id = $1;"
-                , [topicId, content]);
+            const res = await client.query(UPDATE_QUERY, [topicId, content]);
             return;
         } catch (e) {
             throw (e);
@@ -94,20 +109,14 @@ class TopicMgr {
 
         try {
             await client.connect()
-            const res = await client.query(
-                "DELETE FROM topics \
-                WHERE id = $1;"
-                , [topicId]);
+            const res = await client.query(DELETE_QUERY, [topicId])
             return;
-
         } catch (e) {
             throw (e);
         } finally {
             await client.end()
         }
     }
-
-
 }
 
 module.exports = TopicMgr

--- a/src/lib/topicMgr.js
+++ b/src/lib/topicMgr.js
@@ -1,23 +1,5 @@
 import { Client } from 'pg'
-
-const CREATE_QUERY = `
-  INSERT INTO topics(id, expiration) 
-  VALUES ($1, now() + interval '$2' second);
-`
-const READ_QUERY = `
-  SELECT * FROM topics
-  WHERE id=$1
-  AND expiration > now();
-`
-const UPDATE_QUERY = `
-  UPDATE topics 
-  SET content = $2 
-  WHERE id = $1;
-`
-const DELETE_QUERY = `
-  DELETE FROM topics
-  WHERE id = $1;
-`
+import { CREATE_QUERY, READ_QUERY, UPDATE_QUERY, DELETE_QUERY } from './queries.js'
 
 /**
  * @classdesc

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,4 +1,4 @@
-const cryto = require('crypto')
+const crypto = require('crypto')
 
 const BYTELEN = 12
 

--- a/src/lib/util.js
+++ b/src/lib/util.js
@@ -1,0 +1,16 @@
+const cryto = require('crypto')
+
+const BYTELEN = 12
+
+/**
+ * Create a random, url-safe, 16-character, base64 encoded string
+ */
+function randomString() {
+  return crypto.randomBytes(BYTELEN)
+    .toString('base64')
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+}
+
+module.exports = { randomString }


### PR DESCRIPTION
resolves #2 

Allow `POST /topic/:id` to create a new topic, previously only possible with `GET`.  Also add some documentation and extract SQL query strings to a separate file for better management.

This doesn't do anything to save referrer headers with the topic, but I can add that as an extra field in the topic JSON without changing any queries if we want it.