### PR TITLE
feat: add access-control-expose-headers header to responses

### DIFF
--- a/src/api_handler.js
+++ b/src/api_handler.js
@@ -38,7 +38,8 @@ const doHandler = (handler, event, context, callback) => {
     let response
     let corsHeaders = {
       'Access-Control-Allow-Origin': '*',
-      'Access-Control-Allow-Credentials': true
+      'Access-Control-Allow-Credentials': true,
+      'Access-Control-Expose-Headers': 'Location'
     }
     if (err == null) {
       let { code, headers, body } = resp || {}


### PR DESCRIPTION
For the new `POST /topic/` method to work, we need to be able to read the topicId from the 'Location' header, which [isn't exposed in CORS requests by default](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers).  Adding this header will allow it to be read from javascript.  Frustratingly, this doesn't show up as a problem in a node test environment, because it doesn't have the same CORS restrictions.

This should do it, and finally let us use the full features of chasqui from the browser (preflight requests and `Access-Control-Allow-Origin` seem to be working)