### PR TITLE
feat: make {id} param optional for POST /topic/

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -47,7 +47,7 @@ functions:
          request:
             parameters:
               paths:
-                id: true
+                id: false
   topic_get:
     handler: src/api_handler.topic_get
     description: Retrieves a given topic


### PR DESCRIPTION
Just a flip the `required` boolean for `parameters: paths: id` in serverless.yml

This should fix an issue where the AWS api gateway refuses `POST /topic/` with a 502.

